### PR TITLE
Automate formula dialog

### DIFF
--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -482,7 +482,7 @@ class Controller(object):
     def modify_exchange(exchange, field, value):
         # The formula field needs special handling.
         if field == "formula":
-            if field in exchange and value == "":
+            if field in exchange and (value == "" or value is None):
                 # Remove formula entirely.
                 del exchange[field]
                 if "original_amount" in exchange:

--- a/activity_browser/app/ui/tables/activity.py
+++ b/activity_browser/app/ui/tables/activity.py
@@ -41,7 +41,6 @@ class BaseExchangeTable(ABDataFrameEdit):
         self._connect_signals()
 
     def _connect_signals(self):
-        signals.database_changed.connect(lambda: self.sync())
         self.delete_exchange_action.triggered.connect(self.delete_exchanges)
         self.remove_formula_action.triggered.connect(self.remove_formula)
 

--- a/activity_browser/app/ui/tables/activity.py
+++ b/activity_browser/app/ui/tables/activity.py
@@ -233,14 +233,11 @@ class BaseExchangeTable(ABDataFrameEdit):
             act = (ActivityParameter
                    .get(ActivityParameter.database == self.key[0],
                         ActivityParameter.code == self.key[1]))
-            for k, v in ActivityParameter.static(act.group, full=True).items():
-                interpreter.symtable[k] = v
+            interpreter.symtable.update(ActivityParameter.static(act.group, full=True))
         except ActivityParameter.DoesNotExist as e:
             print("Could not find activity: {}".format(e))
-            data = ProjectParameter.static()
-            data.update(DatabaseParameter.static(self.key[0]))
-            for k, v in data.items():
-                interpreter.symtable[k] = v
+            interpreter.symtable.update(ProjectParameter.static())
+            interpreter.symtable.update(DatabaseParameter.static(self.key[0]))
         finally:
             return interpreter
 

--- a/activity_browser/app/ui/tables/parameters.py
+++ b/activity_browser/app/ui/tables/parameters.py
@@ -369,6 +369,9 @@ class ActivityParameterTable(BaseParameterTable):
         self.dataframe = self.dataframe.append(row, ignore_index=True)
         self.sync(self.dataframe)
         self.new_parameter.emit()
+        # Save the new parameter immediately.
+        self.save_parameters()
+        signals.parameters_changed.emit()
 
     @classmethod
     def _build_parameter(cls, key: tuple) -> dict:
@@ -603,7 +606,10 @@ class ExchangesTable(ABDictTreeView):
                      .limit(1)
                      .get())
         except ActivityParameter.DoesNotExist:
-            return
+            signals.add_activity_parameter.emit(key)
+            param = (ActivityParameter
+                     .get(ActivityParameter.database == key[0],
+                          ActivityParameter.code == key[1]))
 
         act = bw.get_activity(key)
         bw.parameters.add_exchanges_to_group(param.group, act)

--- a/activity_browser/app/ui/tables/parameters.py
+++ b/activity_browser/app/ui/tables/parameters.py
@@ -152,14 +152,13 @@ class ProjectParameterTable(BaseParameterTable):
     @staticmethod
     def get_usable_parameters() -> list:
         return [
-            [p.name, p.amount, "project"] for p in ProjectParameter.select()
+            [k, v, "project"] for k, v in ProjectParameter.static().items()
         ]
 
     @staticmethod
     def get_interpreter() -> Interpreter:
         interpreter = Interpreter()
-        for k, v in ProjectParameter.static().items():
-            interpreter.symtable[k] = v
+        interpreter.symtable.update(ProjectParameter.static())
         return interpreter
 
 
@@ -254,8 +253,7 @@ class DataBaseParameterTable(BaseParameterTable):
         """
         interpreter = ProjectParameterTable.get_interpreter()
         db_name = self.get_current_database()
-        for k, v in DatabaseParameter.static(db_name).items():
-            interpreter.symtable[k] = v
+        interpreter.symtable.update(DatabaseParameter.static(db_name))
         return interpreter
 
 
@@ -426,8 +424,7 @@ class ActivityParameterTable(BaseParameterTable):
         menu.addAction(
             qicons.delete, "Remove order from group(s)", self.unset_group_order
         )
-        menu.popup(event.globalPos())
-        menu.exec()
+        menu.exec(event.globalPos())
 
     @pyqtSlot()
     def open_activity_tab(self):
@@ -572,8 +569,7 @@ class ActivityParameterTable(BaseParameterTable):
     def get_interpreter(self) -> Interpreter:
         interpreter = Interpreter()
         group = self.get_current_group()
-        for k, v in ActivityParameter.static(group, full=True).items():
-            interpreter.symtable[k] = v
+        interpreter.symtable.update(ActivityParameter.static(group, full=True))
         return interpreter
 
 

--- a/activity_browser/app/ui/tabs/activity.py
+++ b/activity_browser/app/ui/tabs/activity.py
@@ -70,7 +70,6 @@ class ActivityTab(QtWidgets.QTabWidget):
 
     def __init__(self, key, parent=None, read_only=True):
         super(ActivityTab, self).__init__(parent)
-        self.parent = parent
         self.read_only = read_only
         self.db_read_only = bc.is_database_read_only(db_name=key[0])
         self.key = key
@@ -149,6 +148,7 @@ class ActivityTab(QtWidgets.QTabWidget):
 
     def connect_signals(self):
         signals.database_read_only_changed.connect(self.db_read_only_changed)
+        signals.parameters_changed.connect(self.populate)
         # signals.activity_modified.connect(self.update_activity_values)
 
     @QtCore.pyqtSlot()

--- a/activity_browser/app/ui/tabs/activity.py
+++ b/activity_browser/app/ui/tabs/activity.py
@@ -33,7 +33,7 @@ class ActivitiesTab(ABTab):
             act = bw.get_activity(key)
             if not act.production():
                 return
-            new_tab = ActivityTab(key, parent=self)
+            new_tab = ActivityTab(key)
             self.tabs[key] = new_tab
             self.addTab(new_tab, bc.get_activity_name(act, str_length=30))
 
@@ -52,7 +52,7 @@ class ActivitiesTab(ABTab):
                 pass
 
 
-class ActivityTab(QtWidgets.QTabWidget):
+class ActivityTab(QtWidgets.QWidget):
     """The data relating to Brightway activities can be viewed and edited through this panel interface
     The interface is a GUI representation of the standard activity data format as determined by Brightway
     This is necessitated as AB does not save its own data structures to disk

--- a/activity_browser/app/ui/tabs/parameters.py
+++ b/activity_browser/app/ui/tabs/parameters.py
@@ -37,7 +37,8 @@ class ParametersTab(QTabWidget):
         self._connect_signals()
 
     def _connect_signals(self):
-        signals.add_activity_parameter.connect(self.activity_parameter_added)
+        # signals.add_activity_parameter.connect(self.activity_parameter_added)
+        pass
 
     @pyqtSlot()
     def activity_parameter_added(self) -> None:


### PR DESCRIPTION
Will automatically handle creating a new ActivityParameter when a formula is added to an exchange for an unparameterized activity.
Will ensure the original amount is restored when a formula is removed.
Has a fix for the continuous `RuntimeError: wrapped C/C++ object of type <exchangetable> has been deleted`, namely: Trigger the table updates from the parent tab instead of the table itself.