### PR TITLE
Scenario analysis result selection

### DIFF
--- a/activity_browser/app/bwutils/multilca.py
+++ b/activity_browser/app/bwutils/multilca.py
@@ -260,6 +260,10 @@ class Contributions(object):
         If the given `mlca` object is not an instance of `MLCA`
 
     """
+    ACT = "process"
+    EF = "elementary_flow"
+    TECH = "technosphere"
+    BIOS = "biosphere"
 
     DEFAULT_ACT_FIELDS = ['reference product', 'name', 'location', 'unit', 'database']
     DEFAULT_EF_FIELDS = ['name', 'categories', 'type', 'unit', 'database']
@@ -277,6 +281,20 @@ class Contributions(object):
         # Set default metadata keys (those not in the dataframe will be eliminated)
         self.act_fields = AB_metadata.get_existing_fields(self.DEFAULT_ACT_FIELDS)
         self.ef_fields = AB_metadata.get_existing_fields(self.DEFAULT_EF_FIELDS)
+
+        # Specific datastructures for retrieving relevant MLCA data
+        # inventory: inventory, reverse index, metadata keys, metadata fields
+        self.inventory_data = {
+            "biosphere": (self.mlca.inventory, self.mlca.rev_biosphere_dict,
+                          self.mlca.fu_activity_keys, self.ef_fields),
+            "technosphere": (self.mlca.technosphere_flows, self.mlca.rev_activity_dict,
+                             self.mlca.fu_activity_keys, self.act_fields),
+        }
+        # aggregation: reverse index, metadata keys, metadata fields
+        self.aggregate_data = {
+            "biosphere": (self.mlca.rev_biosphere_dict, self.mlca.lca.biosphere_dict, self.ef_fields),
+            "technosphere": (self.mlca.rev_activity_dict, self.mlca.lca.activity_dict, self.act_fields),
+        }
 
     def normalize(self, contribution_array):
         """Normalise the contribution array.

--- a/activity_browser/app/bwutils/multilca.py
+++ b/activity_browser/app/bwutils/multilca.py
@@ -636,29 +636,23 @@ class Contributions(object):
         """
         C = self.get_contributions('elementary_flow', functional_unit, method)
 
+        x_fields = self._contribution_rows(self.EF, aggregator)
+        index, y_fields = self._contribution_index_cols(method)
         if aggregator:
             (C, rev_index) = self.aggregate_by_parameters(C, aggregator, 'biosphere')
-            x_fields = aggregator if isinstance(aggregator, list) else [aggregator]
             mask = rev_index.values()
         else:
             rev_index = self.mlca.rev_biosphere_dict
-            x_fields = self.ef_fields
             mask = None
 
         # Normalise if required
         if normalize:
             C = self.normalize(C)
 
-        if method:
-            top_cont_dict = self._build_dict(
-                C, self.mlca.fu_index, rev_index, limit, limit_type)
-            return self.get_labelled_contribution_dict(
-                top_cont_dict, x_fields=x_fields, y_fields=self.act_fields, mask=mask)
-        elif functional_unit:
-            top_cont_dict = self._build_dict(
-                C, self.mlca.method_index, rev_index, limit, limit_type)
-            return self.get_labelled_contribution_dict(
-                top_cont_dict, x_fields=x_fields, y_fields=None, mask=mask)
+        top_cont_dict = self._build_dict(C, index, rev_index, limit, limit_type)
+        return self.get_labelled_contribution_dict(
+            top_cont_dict, x_fields=x_fields, y_fields=y_fields, mask=mask
+        )
 
     def top_process_contributions(self, functional_unit=None, method=None,
                                   aggregator=None, limit=5, normalize=False,
@@ -692,26 +686,20 @@ class Contributions(object):
         """
         C = self.get_contributions('process', functional_unit, method)
 
+        x_fields = self._contribution_rows(self.ACT, aggregator)
+        index, y_fields = self._contribution_index_cols(method)
         if aggregator:
             (C, rev_index) = self.aggregate_by_parameters(C, aggregator, 'technosphere')
-            x_fields = aggregator if isinstance(aggregator, list) else [aggregator]
             mask = rev_index.values()
         else:
             rev_index = self.mlca.rev_activity_dict
-            x_fields = self.act_fields
             mask = None
 
         # Normalise if required
         if normalize:
             C = self.normalize(C)
 
-        if method:
-            top_cont_dict = self._build_dict(
-                C, self.mlca.fu_index, rev_index, limit, limit_type)
-            return self.get_labelled_contribution_dict(
-                top_cont_dict, x_fields=x_fields, y_fields=self.act_fields, mask=mask)
-        elif functional_unit:
-            top_cont_dict = self._build_dict(
-                C, self.mlca.method_index, rev_index, limit, limit_type)
-            return self.get_labelled_contribution_dict(
-                top_cont_dict, x_fields=x_fields, y_fields=None, mask=mask)
+        top_cont_dict = self._build_dict(C, index, rev_index, limit, limit_type)
+        return self.get_labelled_contribution_dict(
+            top_cont_dict, x_fields=x_fields, y_fields=y_fields, mask=mask
+        )

--- a/activity_browser/app/bwutils/multilca.py
+++ b/activity_browser/app/bwutils/multilca.py
@@ -228,6 +228,12 @@ class MLCA(object):
         """
         return self.lca_scores / self.lca_scores.max(axis=0)
 
+    def get_normalized_scores_df(self) -> pd.DataFrame:
+        """ To be used for the currently inactive CorrelationPlot.
+        """
+        labels = [str(x + 1) for x in range(len(self.func_units))]
+        return pd.DataFrame(data=self.lca_scores_normalized.T, columns=labels)
+
     def get_all_metadata(self) -> None:
         """Populate AB_metadata with relevant database values.
 

--- a/activity_browser/app/bwutils/multilca.py
+++ b/activity_browser/app/bwutils/multilca.py
@@ -575,15 +575,14 @@ class Contributions(object):
         -------
 
         """
+        rev_index, keys, fields = self.aggregate_data[inventory]
+        if not parameters:
+            return C, rev_index
+
         df = pd.DataFrame(C).T
         columns = list(range(C.shape[0]))
-
-        if inventory == 'biosphere':
-            df.index = pd.MultiIndex.from_tuples(self.mlca.rev_biosphere_dict.values())
-            metadata = AB_metadata.get_metadata(list(self.mlca.lca.biosphere_dict), self.ef_fields)
-        elif inventory == 'technosphere':
-            df.index = pd.MultiIndex.from_tuples(self.mlca.rev_activity_dict.values())
-            metadata = AB_metadata.get_metadata(list(self.mlca.lca.activity_dict), self.act_fields)
+        df.index = pd.MultiIndex.from_tuples(rev_index.values())
+        metadata = AB_metadata.get_metadata(list(keys), fields)
 
         joined = metadata.join(df)
         joined.reset_index(inplace=True, drop=True)

--- a/activity_browser/app/bwutils/multilca.py
+++ b/activity_browser/app/bwutils/multilca.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from typing import Iterable, Optional, Union
+
 import numpy as np
 import pandas as pd
 import brightway2 as bw
@@ -590,6 +592,16 @@ class Contributions(object):
         mask_index = {i: m for i, m in enumerate(aggregated.index)}
 
         return aggregated.T.values, mask_index
+
+    def _contribution_rows(self, contribution: str, aggregator=None):
+        if aggregator is None:
+            return self.act_fields if contribution == self.ACT else self.ef_fields
+        return aggregator if isinstance(aggregator, list) else [aggregator]
+
+    def _contribution_index_cols(self, method=None) -> (dict, Optional[Iterable]):
+        if method:
+            return self.mlca.fu_index, self.act_fields
+        return self.mlca.method_index, None
 
     def top_elementary_flow_contributions(self, functional_unit=None, method=None,
                                           aggregator=None, limit=5, normalize=False,

--- a/activity_browser/app/bwutils/multilca.py
+++ b/activity_browser/app/bwutils/multilca.py
@@ -218,6 +218,10 @@ class MLCA(object):
         databases.add(bw.config.biosphere)
         return databases
 
+    def get_results_for_method(self, index: int = 0) -> pd.DataFrame:
+        data = self.lca_scores[:, index]
+        return pd.DataFrame(data, index=self.func_key_list)
+
     @property
     def lca_scores_normalized(self) -> np.ndarray:
         """Normalize LCA scores by impact assessment method.

--- a/activity_browser/app/bwutils/multilca.py
+++ b/activity_browser/app/bwutils/multilca.py
@@ -398,6 +398,8 @@ class Contributions(object):
         for k in keys:
             if mask and k in mask:
                 translated_keys.append(k)
+            elif isinstance(k, str):
+                translated_keys.append(k)
             elif k in AB_metadata.index:
                 translated_keys.append(separator.join([str(l) for l in list(AB_metadata.get_metadata(k, fields))]))
             else:
@@ -610,8 +612,8 @@ class Contributions(object):
             return self.act_fields if contribution == self.ACT else self.ef_fields
         return aggregator if isinstance(aggregator, list) else [aggregator]
 
-    def _contribution_index_cols(self, method=None) -> (dict, Optional[Iterable]):
-        if method:
+    def _contribution_index_cols(self, **kwargs) -> (dict, Optional[Iterable]):
+        if kwargs.get("method") is not None:
             return self.mlca.fu_index, self.act_fields
         return self.mlca.method_index, None
 
@@ -649,7 +651,9 @@ class Contributions(object):
         C = self.get_contributions(self.EF, functional_unit, method)
 
         x_fields = self._contribution_rows(self.EF, aggregator)
-        index, y_fields = self._contribution_index_cols(method)
+        index, y_fields = self._contribution_index_cols(
+            functional_unit=functional_unit, method=method
+        )
         C, rev_index, mask = self.aggregate_by_parameters(C, self.BIOS, aggregator)
 
         # Normalise if required
@@ -694,7 +698,9 @@ class Contributions(object):
         C = self.get_contributions(self.ACT, functional_unit, method)
 
         x_fields = self._contribution_rows(self.ACT, aggregator)
-        index, y_fields = self._contribution_index_cols(method)
+        index, y_fields = self._contribution_index_cols(
+            functional_unit=functional_unit, method=method
+        )
         C, rev_index, mask = self.aggregate_by_parameters(C, self.TECH, aggregator)
 
         # Normalise if required

--- a/activity_browser/app/bwutils/multilca.py
+++ b/activity_browser/app/bwutils/multilca.py
@@ -493,16 +493,12 @@ class Contributions(object):
         joined.reset_index(inplace=True, drop=True)
         return joined
 
-    def inventory_df(self, inventory_type='biosphere'):
+    def inventory_df(self, inventory_type: str):
         """Returns an inventory dataframe with metadata of the given type.
         """
-        if inventory_type == 'biosphere':
-            data = (self.mlca.inventory, self.mlca.rev_biosphere_dict,
-                    self.mlca.fu_activity_keys, self.ef_fields)
-        elif inventory_type == 'technosphere':
-            data = (self.mlca.technosphere_flows, self.mlca.rev_activity_dict,
-                    self.mlca.fu_activity_keys, self.act_fields)
-        else:
+        try:
+            data = self.inventory_data[inventory_type]
+        except KeyError:
             raise ValueError(
                 "Type must be either 'biosphere' or 'technosphere', "
                 "'{}' given.".format(inventory_type)
@@ -597,7 +593,7 @@ class Contributions(object):
 
     def top_elementary_flow_contributions(self, functional_unit=None, method=None,
                                           aggregator=None, limit=5, normalize=False,
-                                          limit_type="number"):
+                                          limit_type="number", **kwargs):
         """Return top EF contributions for either functional_unit or method.
 
         * If functional_unit: Compare the unit against all considered impact
@@ -654,7 +650,7 @@ class Contributions(object):
 
     def top_process_contributions(self, functional_unit=None, method=None,
                                   aggregator=None, limit=5, normalize=False,
-                                  limit_type="number"):
+                                  limit_type="number", **kwargs):
         """Return top process contributions for functional_unit or method
 
         * If functional_unit: Compare the process against all considered impact

--- a/activity_browser/app/bwutils/presamples/manager.py
+++ b/activity_browser/app/bwutils/presamples/manager.py
@@ -193,7 +193,7 @@ class PresamplesParameterManager(object):
                 input_key = (exc.input_database, exc.input_code)
                 output_key = (exc.output_database, exc.output_code)
                 if exc.input_database == bw.config.biosphere:
-                    indices.append((input_key, output_key))
+                    indices.append((input_key, output_key, "biosphere"))
                 else:
                     indices.append((input_key, output_key, "technosphere"))
             complete_data.extend(data)

--- a/activity_browser/app/bwutils/presamples/manager.py
+++ b/activity_browser/app/bwutils/presamples/manager.py
@@ -181,8 +181,12 @@ class PresamplesParameterManager(object):
             act = self.recalculate_activity_parameters(p.group, combination)
             combination.update(act)
 
+            recalculated = self.recalculate_exchanges(p.group, global_params=combination)
+            # If the parameter group contains no ParameterizedExchanges, skip.
+            if not recalculated:
+                continue
             # `data` contains the recalculated amounts for the exchanges.
-            ids, data = zip(*self.recalculate_exchanges(p.group, global_params=combination))
+            ids, data = zip(*recalculated)
             indices = []
             for pk in ids:
                 exc = ExchangeDataset.get_by_id(pk)

--- a/activity_browser/app/bwutils/presamples/manager.py
+++ b/activity_browser/app/bwutils/presamples/manager.py
@@ -207,6 +207,13 @@ class PresamplesParameterManager(object):
         indices = np.array(complete_indices)
         return samples, indices
 
+    @staticmethod
+    def can_build_presamples() -> bool:
+        """ Test if ParameterizedExchanges exist, no point to building presamples
+         otherwise
+        """
+        return ParameterizedExchange.select().exists()
+
     def presamples_from_scenarios(self, name: str, scenarios: Iterable[Tuple[str, Iterable]]) -> (str, str):
         """ When given a iterable of multiple parameter scenarios, construct
         a presamples package with all of the recalculated exchange amounts.

--- a/activity_browser/app/bwutils/presamples/presamples_mlca.py
+++ b/activity_browser/app/bwutils/presamples/presamples_mlca.py
@@ -165,3 +165,29 @@ class PresamplesContributions(Contributions):
     def _build_contributions(self, data: np.ndarray, index: int, axis: int) -> np.ndarray:
         data = data[:, :, self.mlca.current]
         return super()._build_contributions(data, index, axis)
+
+    @staticmethod
+    def _build_scenario_contributions(data: np.ndarray, fu_index: int, m_index: int) -> np.ndarray:
+        return data[fu_index, m_index, :]
+
+    def get_contributions(self, contribution, functional_unit=None,
+                          method=None) -> np.ndarray:
+        """Return a contribution matrix given the type and fu / method
+
+        Allow for both fu and method to exist.
+        """
+        if not any([functional_unit, method]):
+            raise ValueError(
+                "Either functional unit, method or both should be given. Provided:"
+                "\n Functional unit: {} \n Method: {}".format(functional_unit, method)
+            )
+        dataset = {
+            'process': self.mlca.process_contributions,
+            'elementary_flow': self.mlca.elementary_flow_contributions,
+        }
+        if method and functional_unit:
+            return self._build_scenario_contributions(
+                dataset[contribution], self.mlca.func_key_dict[functional_unit],
+                self.mlca.method_index[method]
+            )
+        return super().get_contributions(contribution, functional_unit, method)

--- a/activity_browser/app/bwutils/presamples/presamples_mlca.py
+++ b/activity_browser/app/bwutils/presamples/presamples_mlca.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from ast import literal_eval
-from typing import List, Union
+from typing import Iterable, List, Optional
 
 import brightway2 as bw
 import numpy as np
@@ -26,6 +26,9 @@ class PresamplesMLCA(MLCA):
         data = self.resource.metadata
         self.total = data.get("ncols", 1)
         self._current_index = 0
+
+        # Construct an index dictionary similar to fu_index and method_index
+        self.presamples_index = {k: i for i, k in enumerate(self.get_scenario_names())}
 
         # Rebuild numpy arrays with presample dimension included.
         self.lca_scores = np.zeros((len(self.func_units), len(self.methods), self.total))
@@ -191,3 +194,10 @@ class PresamplesContributions(Contributions):
                 self.mlca.method_index[method]
             )
         return super().get_contributions(contribution, functional_unit, method)
+
+    def _contribution_index_cols(self, **kwargs) -> (dict, Optional[Iterable]):
+        # If both functional_unit and method are given, return presamples index.
+        if all(kwargs.values()):
+            return self.mlca.presamples_index, self.act_fields
+        else:
+            return super()._contribution_index_cols(**kwargs)

--- a/activity_browser/app/bwutils/presamples/presamples_mlca.py
+++ b/activity_browser/app/bwutils/presamples/presamples_mlca.py
@@ -56,7 +56,9 @@ class PresamplesMLCA(MLCA):
         """ Set the current scenario index given a new index to go to
         """
         steps = self._get_steps_to_index(index)
-        self.current = steps[-1] + 1  # Walk the steps to the new index
+        # self.current = steps[-1] + 1  # Walk the steps to the new index
+        for _ in steps:
+            self.next_scenario()
 
     def _construct_lca(self) -> bw.LCA:
         return bw.LCA(
@@ -153,6 +155,8 @@ class PresamplesMLCA(MLCA):
 
 
 class PresamplesContributions(Contributions):
+    mlca: PresamplesMLCA
+
     def __init__(self, mlca):
         if not isinstance(mlca, PresamplesMLCA):
             raise TypeError("Must pass a PresamplesMLCA object. Passed: {}".format(type(mlca)))

--- a/activity_browser/app/bwutils/presamples/presamples_mlca.py
+++ b/activity_browser/app/bwutils/presamples/presamples_mlca.py
@@ -96,6 +96,15 @@ class PresamplesMLCA(MLCA):
                     self.process_contributions[row, col, ps_col] = self.lca.characterized_inventory.sum(axis=0)
             self.next_scenario()
 
+    def get_results_for_method(self, index: int = 0) -> pd.DataFrame:
+        """ Overrides the parent and returns a dataframe with the scenarios
+         as columns
+        """
+        data = self.lca_scores[:, index, :]
+        return pd.DataFrame(
+            data, index=self.func_key_list, columns=self.get_scenario_names()
+        )
+
     @property
     def lca_scores_normalized(self) -> np.ndarray:
         """Normalize LCA scores by impact assessment method.

--- a/activity_browser/app/ui/figures.py
+++ b/activity_browser/app/ui/figures.py
@@ -153,13 +153,14 @@ class LCAResultsPlot(Plot):
 
 
 class ContributionPlot(Plot):
+    MAX_LEGEND = 30
+
     def __init__(self):
         super().__init__()
         self.plot_name = 'Contributions'
 
     def plot(self, df: pd.DataFrame, unit: str = None):
         """ Plot a horizontal bar chart of the process contributions. """
-        max_legend_items = 30
         dfp = df.copy()
         dfp.index = dfp['index']
         dfp.drop(dfp.select_dtypes(['object']), axis=1, inplace=True)  # get rid of all non-numeric columns (metadata)
@@ -169,29 +170,29 @@ class ContributionPlot(Plot):
         self.ax.clear()
         canvas_width_inches, canvas_height_inches = self.get_canvas_size_in_inches()
         optimal_height_inches = 4 + dfp.shape[1] * 0.55
-        print('Optimal Contribution plot height:', optimal_height_inches)
+        # print('Optimal Contribution plot height:', optimal_height_inches)
         self.figure.set_size_inches(canvas_width_inches, optimal_height_inches)
 
         # avoid figures getting too large horizontally
         dfp.index = [wrap_text(str(i), max_length=40) for i in dfp.index]
         dfp.columns = [wrap_text(i, max_length=40) for i in dfp.columns]
 
-        plot = dfp.T.plot.barh(
+        dfp.T.plot.barh(
             stacked=True,
             cmap=plt.cm.nipy_spectral_r,
             ax=self.ax,
-            legend=False if dfp.shape[0] >= max_legend_items else True,
+            legend=False if dfp.shape[0] >= self.MAX_LEGEND else True,
         )
-        plot.tick_params(labelsize=8)
+        self.ax.tick_params(labelsize=8)
         if unit:
             self.ax.set_xlabel(unit)
 
         # show legend if not too many items
-        if not dfp.shape[0] >= max_legend_items:
+        if not dfp.shape[0] >= self.MAX_LEGEND:
             plt.rc('legend', **{'fontsize': 8})
             ncols = math.ceil(dfp.shape[0] * 0.6 / optimal_height_inches)
             # print('Ncols:', ncols, dfp.shape[0] * 0.55, optimal_height_inches)
-            legend = plot.legend(loc='center left', bbox_to_anchor=(1, 0.5), ncol=ncols)
+            self.ax.legend(loc='center left', bbox_to_anchor=(1, 0.5), ncol=ncols)
 
         # grid
         self.ax.grid(which="major", axis="x", color="grey", linestyle='dashed')
@@ -204,10 +205,6 @@ class ContributionPlot(Plot):
         size_pixels = self.figure.get_size_inches() * self.figure.dpi
         self.setMinimumHeight(size_pixels[1])
         self.canvas.draw()
-
-        # self.canvas.draw()
-        # size_pixels = self.figure.get_size_inches() * self.figure.dpi
-        # self.setMinimumHeight(size_pixels[1])
 
 
 class CorrelationPlot(Plot):

--- a/activity_browser/app/ui/figures.py
+++ b/activity_browser/app/ui/figures.py
@@ -40,6 +40,7 @@ class Plot(QtWidgets.QWidget):
         layout.addWidget(self.canvas)
         self.setLayout(layout)
         self.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        self.updateGeometry()
 
     def plot(self, *args, **kwargs):
         raise NotImplementedError

--- a/activity_browser/app/ui/tabs/LCA_results_tabs.py
+++ b/activity_browser/app/ui/tabs/LCA_results_tabs.py
@@ -704,6 +704,7 @@ class ElementaryFlowContributionTab(ContributionTab):
         self.layout.addWidget(horizontal_line())
         self.layout.addWidget(self.build_main_space())
         self.layout.addLayout(self.build_export(True, True))
+        self.set_combobox_changes()
 
         self.contribution_fn = 'EF contributions'
         self.connect_signals()
@@ -734,6 +735,7 @@ class ProcessContributionsTab(ContributionTab):
         self.layout.addWidget(horizontal_line())
         self.layout.addWidget(self.build_main_space())
         self.layout.addLayout(self.build_export(True, True))
+        self.set_combobox_changes()
 
         self.contribution_fn = 'Process contributions'
         self.connect_signals()

--- a/activity_browser/app/ui/tabs/LCA_results_tabs.py
+++ b/activity_browser/app/ui/tabs/LCA_results_tabs.py
@@ -664,25 +664,17 @@ class ContributionTab(NewAnalysisTab):
         if self.has_method and self.has_func:
             self.switches.method.toggled.connect(self.toggle_method)
             self.switches.func.toggled.connect(self.toggle_func)
+            if self.using_presamples:
+                self.switches.scenario.toggled.connect(self.toggle_scenario)
+            self.switch_buttons.buttonToggled.connect(self.set_combobox_changes)
             self.switch_buttons.buttonToggled.connect(self.update_tab)
 
-        self.combobox_menu.method.currentTextChanged.connect(
-            lambda name: self.update_plot(method=name)
-        )
-        self.combobox_menu.func.currentTextChanged.connect(
-            lambda name: self.update_plot(method=name)
-        )
-        self.combobox_menu.agg.currentTextChanged.connect(
-            lambda a: self.update_plot(aggregator=a))
-
-        self.combobox_menu.method.currentTextChanged.connect(
-            lambda name: self.update_table()
-        )
-        self.combobox_menu.func.currentTextChanged.connect(
-            lambda name: self.update_table()
-        )
-        self.combobox_menu.agg.currentTextChanged.connect(
-            lambda a: self.update_table())
+        self.combobox_menu.method.currentIndexChanged.connect(self.set_combobox_changes)
+        self.combobox_menu.func.currentIndexChanged.connect(self.set_combobox_changes)
+        self.combobox_menu.agg.currentIndexChanged.connect(self.set_combobox_changes)
+        self.combobox_menu.method.currentIndexChanged.connect(self.update_tab)
+        self.combobox_menu.func.currentIndexChanged.connect(self.update_tab)
+        self.combobox_menu.agg.currentIndexChanged.connect(self.update_tab)
 
         # Add wiring for presamples scenarios
         if self.using_presamples:
@@ -690,48 +682,14 @@ class ContributionTab(NewAnalysisTab):
             self.parent.update_scenario_box_index.connect(
                 lambda index: self.set_combobox_index(self.scenario_box, index)
             )
-            self.switches.scenario.toggled.connect(self.toggle_scenario)
 
     def update_dataframe(self, *args, **kwargs):
         """Updates the underlying dataframe. Implement in subclass.
         """
         raise NotImplementedError
 
-    def update_table(self, *args, **kwargs):
-        super().update_table(*args, **kwargs)
-
-    def update_plot(self, method=None, aggregator=None):
-        if self.switches.func.isChecked():
-            if self.current_method and method is None:
-                method = self.current_method
-            elif method is None or method == '':
-                method = self.parent.mlca.methods[0]
-            else:
-                method = self.parent.method_dict[method]
-            func = None
-        else:
-            func = method
-            if self.current_func and func is None:
-                func = self.current_func
-            if func is None or func == '':
-                func = self.parent.mlca.func_key_list[0]
-            method = None
-
-        if self.current_agg and aggregator is None:
-            aggregator = self.current_agg
-        elif aggregator == 'none':
-            aggregator = None
-
-        self.current_method = method
-        self.current_func = func
-        self.current_agg = aggregator
-
-        self.df = self.update_dataframe()
-        unit = get_unit(method, self.relative)
-        self.plot.plot(self.df, unit=unit)
-        filename = '_'.join([str(x) for x in [self.parent.cs_name, self.contribution_fn, method, func, unit]
-                             if x is not None])
-        self.plot.plot_name, self.table.table_name = filename, filename
+    def update_plot(self):
+        self.plot.plot(self.df, unit=self.unit)
 
 
 class ElementaryFlowContributionTab(ContributionTab):

--- a/activity_browser/app/ui/tabs/LCA_results_tabs.py
+++ b/activity_browser/app/ui/tabs/LCA_results_tabs.py
@@ -581,6 +581,15 @@ class ContributionTab(NewAnalysisTab):
         self.has_func = has_func
         return menu
 
+    def configure_scenario(self):
+        """ Supplement the superclass method because there are more things to
+         hide in these tabs.
+        """
+        super().configure_scenario()
+        visible = self.parent.using_presamples if self.parent else False
+        self.switches.scenario.setVisible(visible)
+        self.combobox_menu.scenario_label.setVisible(visible)
+
     @QtCore.Slot(bool, name="hideScenarioCombo")
     def toggle_scenario(self, active: bool):
         self.combobox_menu.scenario.setHidden(active)

--- a/activity_browser/app/ui/tabs/LCA_results_tabs.py
+++ b/activity_browser/app/ui/tabs/LCA_results_tabs.py
@@ -702,7 +702,6 @@ class ElementaryFlowContributionTab(ContributionTab):
         self.layout.addWidget(horizontal_line())
         self.layout.addWidget(self.build_main_space())
         self.layout.addLayout(self.build_export(True, True))
-        self.set_combobox_changes()
 
         self.contribution_fn = 'EF contributions'
         self.connect_signals()
@@ -733,7 +732,6 @@ class ProcessContributionsTab(ContributionTab):
         self.layout.addWidget(horizontal_line())
         self.layout.addWidget(self.build_main_space())
         self.layout.addLayout(self.build_export(True, True))
-        self.set_combobox_changes()
 
         self.contribution_fn = 'Process contributions'
         self.connect_signals()

--- a/activity_browser/app/ui/tabs/LCA_results_tabs.py
+++ b/activity_browser/app/ui/tabs/LCA_results_tabs.py
@@ -382,14 +382,13 @@ class InventoryTab(NewAnalysisTab):
         self.df_biosphere, self.df_technosphere = None, None
 
 
-class LCAResultsTab(QWidget):
+class LCAResultsTab(NewAnalysisTab):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.parent = parent
         self.lca_scores_widget = LCAScoresTab(parent)
         self.lca_overview_widget = LCIAResultsTab(parent)
 
-        self.layout = QVBoxLayout()
         self.layout.setAlignment(QtCore.Qt.AlignTop)
         self.layout.addLayout(get_header_layout('LCA Results'))
 
@@ -403,14 +402,12 @@ class LCAResultsTab(QWidget):
         self.button_group.addButton(self.button_overview, 0)
         self.button_group.addButton(self.button_by_method, 1)
         button_layout.addWidget(self.button_by_method)
-        self.scenario_box = QComboBox()
         button_layout.addWidget(self.scenario_box)
         button_layout.addStretch(1)
         self.layout.addLayout(button_layout)
 
         self.layout.addWidget(self.lca_scores_widget)
         self.layout.addWidget(self.lca_overview_widget)
-        self.setLayout(self.layout)
 
         self.button_clicked(False)
         self.connect_signals()
@@ -419,7 +416,6 @@ class LCAResultsTab(QWidget):
         self.button_overview.toggled.connect(self.button_clicked)
         if self.parent:
             self.scenario_box.currentIndexChanged.connect(self.parent.update_scenario_data)
-            self.parent.update_scenario_box_index.connect(self.update_scenario_box)
 
     @QtCore.Slot(bool, name="overviewToggled")
     def button_clicked(self, is_overview: bool):
@@ -430,12 +426,6 @@ class LCAResultsTab(QWidget):
         self.lca_scores_widget.update_tab()
         self.lca_overview_widget.update_plot()
         self.lca_overview_widget.update_table()
-
-    @QtCore.Slot(int)
-    def update_scenario_box(self, index: int) -> None:
-        self.scenario_box.blockSignals(True)
-        self.scenario_box.setCurrentIndex(index)
-        self.scenario_box.blockSignals(False)
 
 
 class LCAScoresTab(NewAnalysisTab):

--- a/activity_browser/app/ui/tabs/LCA_results_tabs.py
+++ b/activity_browser/app/ui/tabs/LCA_results_tabs.py
@@ -551,9 +551,6 @@ class ContributionTab(NewAnalysisTab):
         self.contribution_fn = None
         self.has_method, self.has_func = False, False
         self.unit = None
-        self.current_method = None
-        self.current_func = None
-        self.current_agg = None  # Default to no aggregation
 
     def set_filename(self, optional_fields: dict = None):
         """ Given a dictionary of fields, put together a usable filename
@@ -666,12 +663,9 @@ class ContributionTab(NewAnalysisTab):
             self.switches.func.toggled.connect(self.toggle_func)
             if self.using_presamples:
                 self.switches.scenario.toggled.connect(self.toggle_scenario)
-            self.switch_buttons.buttonToggled.connect(self.set_combobox_changes)
+                self.combobox_menu.scenario.currentIndexChanged.connect(self.update_tab)
             self.switch_buttons.buttonToggled.connect(self.update_tab)
 
-        self.combobox_menu.method.currentIndexChanged.connect(self.set_combobox_changes)
-        self.combobox_menu.func.currentIndexChanged.connect(self.set_combobox_changes)
-        self.combobox_menu.agg.currentIndexChanged.connect(self.set_combobox_changes)
         self.combobox_menu.method.currentIndexChanged.connect(self.update_tab)
         self.combobox_menu.func.currentIndexChanged.connect(self.update_tab)
         self.combobox_menu.agg.currentIndexChanged.connect(self.update_tab)
@@ -682,6 +676,10 @@ class ContributionTab(NewAnalysisTab):
             self.parent.update_scenario_box_index.connect(
                 lambda index: self.set_combobox_index(self.scenario_box, index)
             )
+
+    def update_tab(self):
+        self.set_combobox_changes()
+        super().update_tab()
 
     def update_dataframe(self, *args, **kwargs):
         """Updates the underlying dataframe. Implement in subclass.

--- a/activity_browser/app/ui/tabs/LCA_results_tabs.py
+++ b/activity_browser/app/ui/tabs/LCA_results_tabs.py
@@ -358,7 +358,7 @@ class InventoryTab(NewAnalysisTab):
     def connect_signals(self):
         self.radio_button_biosphere.clicked.connect(self.button_clicked)
         self.radio_button_technosphere.clicked.connect(self.button_clicked)
-        if self.parent:
+        if self.using_presamples:
             self.scenario_box.currentIndexChanged.connect(self.parent.update_scenario_data)
             self.parent.update_scenario_box_index.connect(
                 lambda index: self.set_combobox_index(self.scenario_box, index)
@@ -429,8 +429,11 @@ class LCAResultsTab(NewAnalysisTab):
 
     def connect_signals(self):
         self.button_overview.toggled.connect(self.button_clicked)
-        if self.parent:
+        if self.using_presamples:
             self.scenario_box.currentIndexChanged.connect(self.parent.update_scenario_data)
+            self.parent.update_scenario_box_index.connect(
+                lambda index: self.set_combobox_index(self.scenario_box, index)
+            )
 
     @QtCore.Slot(bool, name="overviewToggled")
     def button_clicked(self, is_overview: bool):
@@ -627,10 +630,10 @@ class ContributionTab(NewAnalysisTab):
             lambda a: self.update_plot(aggregator=a))
 
         self.combobox_menu.method.currentTextChanged.connect(
-            lambda name: self.update_table(method=name)
+            lambda name: self.update_table()
         )
         self.combobox_menu.func.currentTextChanged.connect(
-            lambda name: self.update_table(method=name)
+            lambda name: self.update_table()
         )
         self.combobox_menu.agg.currentTextChanged.connect(
             lambda a: self.update_table())
@@ -646,7 +649,7 @@ class ContributionTab(NewAnalysisTab):
     def update_dataframe(self):
         """Updates the underlying dataframe. Implement in sublass.
         """
-        raise NotImplemented
+        raise NotImplementedError
 
     def update_table(self, *args, **kwargs):
         super().update_table(*args, **kwargs)
@@ -809,7 +812,7 @@ class MonteCarloTab(NewAnalysisTab):
         # self.radio_button_biosphere.clicked.connect(self.button_clicked)
         # self.radio_button_technosphere.clicked.connect(self.button_clicked)
 
-        if self.parent:
+        if self.using_presamples:
             self.scenario_box.currentIndexChanged.connect(self.parent.update_scenario_data)
             self.parent.update_scenario_box_index.connect(
                 lambda index: self.set_combobox_index(self.scenario_box, index)

--- a/activity_browser/app/ui/tabs/LCA_results_tabs.py
+++ b/activity_browser/app/ui/tabs/LCA_results_tabs.py
@@ -608,30 +608,28 @@ class ContributionTab(NewAnalysisTab):
     def connect_signals(self):
         """Override the inherited method to perform the same thing plus aggregation
         """
-        if self.combobox_menu:
-            if self.has_method and self.has_func:
-                self.switches.method.toggled.connect(self.toggle_method)
-                self.switches.func.toggled.connect(self.toggle_func)
-                self.switch_buttons.buttonToggled.connect(self.update_tab)
+        if self.has_method and self.has_func:
+            self.switches.method.toggled.connect(self.toggle_method)
+            self.switches.func.toggled.connect(self.toggle_func)
+            self.switch_buttons.buttonToggled.connect(self.update_tab)
 
-            if self.plot:
-                self.combobox_menu.method.currentTextChanged.connect(
-                    lambda name: self.update_plot(method=name)
-                )
-                self.combobox_menu.func.currentTextChanged.connect(
-                    lambda name: self.update_plot(method=name)
-                )
-                self.combobox_menu.agg.currentTextChanged.connect(
-                    lambda a: self.update_plot(aggregator=a))
-            if self.table:
-                self.combobox_menu.method.currentTextChanged.connect(
-                    lambda name: self.update_table(method=name)
-                )
-                self.combobox_menu.func.currentTextChanged.connect(
-                    lambda name: self.update_table(method=name)
-                )
-                self.combobox_menu.agg.currentTextChanged.connect(
-                    lambda a: self.update_table())
+        self.combobox_menu.method.currentTextChanged.connect(
+            lambda name: self.update_plot(method=name)
+        )
+        self.combobox_menu.func.currentTextChanged.connect(
+            lambda name: self.update_plot(method=name)
+        )
+        self.combobox_menu.agg.currentTextChanged.connect(
+            lambda a: self.update_plot(aggregator=a))
+
+        self.combobox_menu.method.currentTextChanged.connect(
+            lambda name: self.update_table(method=name)
+        )
+        self.combobox_menu.func.currentTextChanged.connect(
+            lambda name: self.update_table(method=name)
+        )
+        self.combobox_menu.agg.currentTextChanged.connect(
+            lambda a: self.update_table())
 
         # Add wiring for presamples scenarios
         if self.parent:

--- a/activity_browser/app/ui/tabs/LCA_results_tabs.py
+++ b/activity_browser/app/ui/tabs/LCA_results_tabs.py
@@ -240,16 +240,20 @@ class NewAnalysisTab(QWidget):
         self.relative = checked
         self.update_tab()
 
+    @property
+    def using_presamples(self) -> bool:
+        return self.parent.using_presamples if self.parent else False
+
+    def get_scenario_labels(self) -> List[str]:
+        return self.parent.mlca.get_scenario_names() if self.using_presamples else []
+
     def configure_scenario(self):
         """ Determine if scenario Qt widgets are visible or not and retrieve
          scenario labels for the selection drop-down box.
         """
-        visible = self.parent.using_presamples if self.parent else False
         if self.scenario_box:
-            self.scenario_box.setVisible(visible)
-            if visible:
-                labels = self.parent.mlca.get_scenario_names()
-                self.update_combobox(self.scenario_box, labels)
+            self.scenario_box.setVisible(self.using_presamples)
+            self.update_combobox(self.scenario_box, self.get_scenario_labels())
 
     @staticmethod
     @QtCore.Slot(int, name="setBoxIndex")
@@ -586,7 +590,7 @@ class ContributionTab(NewAnalysisTab):
          hide in these tabs.
         """
         super().configure_scenario()
-        visible = self.parent.using_presamples if self.parent else False
+        visible = self.using_presamples
         self.switches.scenario.setVisible(visible)
         self.combobox_menu.scenario_label.setVisible(visible)
 
@@ -632,13 +636,12 @@ class ContributionTab(NewAnalysisTab):
             lambda a: self.update_table())
 
         # Add wiring for presamples scenarios
-        if self.parent:
+        if self.using_presamples:
             self.scenario_box.currentIndexChanged.connect(self.parent.update_scenario_data)
             self.parent.update_scenario_box_index.connect(
                 lambda index: self.set_combobox_index(self.scenario_box, index)
             )
-            if self.parent.using_presamples:
-                self.switches.scenario.toggled.connect(self.toggle_scenario)
+            self.switches.scenario.toggled.connect(self.toggle_scenario)
 
     def update_dataframe(self):
         """Updates the underlying dataframe. Implement in sublass.

--- a/activity_browser/app/ui/tabs/LCA_results_tabs.py
+++ b/activity_browser/app/ui/tabs/LCA_results_tabs.py
@@ -540,7 +540,6 @@ class ContributionTab(NewAnalysisTab):
         self.df = None
         self.plot = ContributionPlot()
         self.table = ContributionTable(self)
-        self.contribution_type = None
         self.contribution_fn = None
         self.has_method, self.has_func = False, False
         self.current_method = None
@@ -599,25 +598,6 @@ class ContributionTab(NewAnalysisTab):
             self.combobox_menu.method.setVisible(True)
             self.combobox_menu.label.setText(self.combobox_menu.method_label)
         self.update_tab()
-
-    def update_aggregation_combobox(self):
-        """Contribution-specific aggregation combobox
-        """
-        self.combobox_menu.agg.blockSignals(True)
-        self.combobox_menu.agg.clear()
-        aggregator_list = []
-        if self.contribution_type == 'EF':
-            aggregator_list.extend(self.parent.contributions.DEFAULT_EF_AGGREGATES)
-        elif self.contribution_type == 'PC':
-            aggregator_list.extend(self.parent.contributions.DEFAULT_ACT_AGGREGATES)
-        self.combobox_menu.agg.addItems(aggregator_list)
-        self.combobox_menu.agg.blockSignals(False)
-
-    def update_tab(self):
-        """Override and include call to update aggregation combobox"""
-        if self.combobox_menu.agg:
-            self.update_aggregation_combobox()
-        super().update_tab()
 
     def connect_signals(self):
         """Override the inherited method to perform the same thing plus aggregation
@@ -707,9 +687,13 @@ class ElementaryFlowContributionTab(ContributionTab):
         self.layout.addWidget(self.build_main_space())
         self.layout.addLayout(self.build_export(True, True))
 
-        self.contribution_type = 'EF'
         self.contribution_fn = 'EF contributions'
         self.connect_signals()
+
+    def build_combobox(self, has_method: bool = True,
+                       has_func: bool = False) -> QHBoxLayout:
+        self.combobox_menu.agg.addItems(self.parent.contributions.DEFAULT_EF_AGGREGATES)
+        return super().build_combobox(has_method, has_func)
 
     def update_dataframe(self):
         """Retrieve the top elementary flow contributions
@@ -733,9 +717,13 @@ class ProcessContributionsTab(ContributionTab):
         self.layout.addWidget(self.build_main_space())
         self.layout.addLayout(self.build_export(True, True))
 
-        self.contribution_type = 'PC'
         self.contribution_fn = 'Process contributions'
         self.connect_signals()
+
+    def build_combobox(self, has_method: bool = True,
+                       has_func: bool = False) -> QHBoxLayout:
+        self.combobox_menu.agg.addItems(self.parent.contributions.DEFAULT_ACT_AGGREGATES)
+        return super().build_combobox(has_method, has_func)
 
     def update_dataframe(self):
         """Retrieve the top process contributions

--- a/activity_browser/app/ui/tabs/LCA_results_tabs.py
+++ b/activity_browser/app/ui/tabs/LCA_results_tabs.py
@@ -431,11 +431,18 @@ class LCAResultsTab(NewAnalysisTab):
             self.parent.update_scenario_box_index.connect(
                 lambda index: self.set_combobox_index(self.scenario_box, index)
             )
+            self.button_by_method.toggled.connect(
+                lambda on_lcia: self.scenario_box.setHidden(on_lcia)
+            )
 
     @QtCore.Slot(bool, name="overviewToggled")
     def button_clicked(self, is_overview: bool):
         self.lca_overview_widget.setVisible(is_overview)
         self.lca_scores_widget.setHidden(is_overview)
+
+    def configure_scenario(self):
+        super().configure_scenario()
+        self.scenario_box.setHidden(self.button_by_method.isChecked())
 
     def update_tab(self):
         self.lca_scores_widget.update_tab()

--- a/activity_browser/app/ui/tabs/LCA_results_tabs.py
+++ b/activity_browser/app/ui/tabs/LCA_results_tabs.py
@@ -692,8 +692,8 @@ class ContributionTab(NewAnalysisTab):
             )
             self.switches.scenario.toggled.connect(self.toggle_scenario)
 
-    def update_dataframe(self):
-        """Updates the underlying dataframe. Implement in sublass.
+    def update_dataframe(self, *args, **kwargs):
+        """Updates the underlying dataframe. Implement in subclass.
         """
         raise NotImplementedError
 
@@ -755,13 +755,13 @@ class ElementaryFlowContributionTab(ContributionTab):
         self.combobox_menu.agg.addItems(self.parent.contributions.DEFAULT_EF_AGGREGATES)
         return super().build_combobox(has_method, has_func)
 
-    def update_dataframe(self):
+    def update_dataframe(self, *args, **kwargs):
         """Retrieve the top elementary flow contributions
         """
         return self.parent.contributions.top_elementary_flow_contributions(
-            functional_unit=self.current_func, method=self.current_method,
-            aggregator=self.current_agg, limit=self.cutoff_menu.cutoff_value,
-            limit_type=self.cutoff_menu.limit_type, normalize=self.relative)
+            **kwargs, limit=self.cutoff_menu.cutoff_value,
+            limit_type=self.cutoff_menu.limit_type, normalize=self.relative
+        )
 
 
 class ProcessContributionsTab(ContributionTab):
@@ -785,13 +785,13 @@ class ProcessContributionsTab(ContributionTab):
         self.combobox_menu.agg.addItems(self.parent.contributions.DEFAULT_ACT_AGGREGATES)
         return super().build_combobox(has_method, has_func)
 
-    def update_dataframe(self):
+    def update_dataframe(self, *args, **kwargs):
         """Retrieve the top process contributions
         """
         return self.parent.contributions.top_process_contributions(
-            functional_unit=self.current_func, method=self.current_method,
-            aggregator=self.current_agg, limit=self.cutoff_menu.cutoff_value,
-            limit_type=self.cutoff_menu.limit_type, normalize=self.relative)
+            **kwargs, limit=self.cutoff_menu.cutoff_value,
+            limit_type=self.cutoff_menu.limit_type, normalize=self.relative
+        )
 
 
 class CorrelationsTab(NewAnalysisTab):

--- a/activity_browser/app/ui/tabs/LCA_results_tabs.py
+++ b/activity_browser/app/ui/tabs/LCA_results_tabs.py
@@ -284,8 +284,8 @@ class NewAnalysisTab(QWidget):
         self.table.sync(*args, **kwargs)
 
     def update_plot(self, *args, **kwargs):
-        """Updates the plot. Method will be added in subclass."""
-        raise NotImplementedError
+        """Updates the plot. """
+        self.plot.plot(*args, **kwargs)
 
     def build_export(self, has_table: bool = True, has_plot: bool = True) -> QHBoxLayout:
         """ Construct a custom export button layout. """
@@ -389,9 +389,6 @@ class InventoryTab(NewAnalysisTab):
                 self.df_technosphere = self.parent.contributions.inventory_df(inventory_type='technosphere')
             self.table.sync(self.df_technosphere)
 
-    def update_plot(self):
-        pass
-
     def clear_tables(self) -> None:
         """ Set the biosphere and technosphere to None.
         """
@@ -445,9 +442,6 @@ class LCAResultsTab(NewAnalysisTab):
         self.lca_scores_widget.update_tab()
         self.lca_overview_widget.update_plot()
         self.lca_overview_widget.update_table()
-
-    def update_plot(self, *args, **kwargs):
-        pass
 
 
 class LCAScoresTab(NewAnalysisTab):

--- a/activity_browser/app/ui/tabs/LCA_setup.py
+++ b/activity_browser/app/ui/tabs/LCA_setup.py
@@ -152,6 +152,7 @@ class LCASetupTab(QtWidgets.QWidget):
         signals.calculation_setup_selected.connect(lambda: self.show_details())
         signals.calculation_setup_selected.connect(self.enable_calculations)
         signals.calculation_setup_changed.connect(self.enable_calculations)
+        signals.presample_package_created.connect(self.valid_presamples)
 
     def save_cs_changes(self):
         name = self.list_widget.name
@@ -169,6 +170,7 @@ class LCASetupTab(QtWidgets.QWidget):
             self.list_widget.name, self.presamples.list.selection
         )
 
+    @Slot(name="toggleDefaultCalculation")
     def set_default_calculation_setup(self):
         self.calculation_type.setCurrentIndex(0)
         if not len(calculation_setups):
@@ -179,6 +181,7 @@ class LCASetupTab(QtWidgets.QWidget):
                 sorted(calculation_setups)[0]
             )
 
+    @Slot(name="togglePresampleCalculation")
     def valid_presamples(self):
         """ Determine if calculate with presamples is active.
         """

--- a/activity_browser/app/ui/tabs/parameters.py
+++ b/activity_browser/app/ui/tabs/parameters.py
@@ -5,7 +5,7 @@ import brightway2 as bw
 from bw2data.filesystem import safe_filename
 from PySide2.QtCore import Slot, QSize
 from PySide2.QtWidgets import (
-    QCheckBox, QFileDialog, QHBoxLayout, QPushButton, QToolBar,
+    QCheckBox, QFileDialog, QHBoxLayout, QMessageBox, QPushButton, QToolBar,
     QStyle, QVBoxLayout, QTabWidget
 )
 
@@ -320,6 +320,13 @@ class PresamplesTab(BaseRightTab):
             self.tbl.sync(df=df)
 
     def save_scenarios(self):
+        if not PresamplesParameterManager.can_build_presamples():
+            QMessageBox.warning(
+                self, "No parameterized exchanges", "Please set formulas on"
+                " exchanges to make use of scenario analysis.",
+                QMessageBox.Ok, QMessageBox.Ok
+            )
+            return
         filename, _ = QFileDialog().getSaveFileName(
             self, caption="Save current scenarios to TSV",
             dir=project_settings.data_dir, filter=self.tbl.TSV_FILTER

--- a/activity_browser/app/ui/widgets/__init__.py
+++ b/activity_browser/app/ui/widgets/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from .activity import ActivityDataGrid, DetailsGroupBox
 from .biosphere_update import BiosphereUpdater
+from .comparison_switch import SwitchComboBox
 from .cutoff_menu import CutoffMenu
 from .line_edit import (SignalledPlainTextEdit, SignalledComboEdit,
                         SignalledLineEdit)

--- a/activity_browser/app/ui/widgets/comparison_switch.py
+++ b/activity_browser/app/ui/widgets/comparison_switch.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from collections import namedtuple
+
+from PySide2 import QtWidgets
+
+
+Switches = namedtuple("switches", ("func", "method", "scenario"))
+
+
+class SwitchComboBox(QtWidgets.QComboBox):
+    """ For keeping track of contribution tab comparisons.
+    """
+    def __init__(self, parent: QtWidgets.QWidget = None):
+        super().__init__(parent)
+        self.using_presamples = getattr(parent, "using_presamples")
+        self.switches = Switches(
+            "Functional Units", "Impact Categories", "Scenarios"
+        )
+        self.indexes = Switches(0, 1, 2)
+
+    def configure(self, has_func: bool = True, has_method: bool = True):
+        self.blockSignals(True)
+        if all([has_func, has_method]):
+            self.insertItems(0, [self.switches.func, self.switches.method])
+        if self.using_presamples:
+            self.insertItems(self.indexes.scenario, [self.switches.scenario])
+        self.setVisible(self.count() > 0)
+        self.blockSignals(False)


### PR DESCRIPTION
Now that we have an additional dimension of data, we need to properly parse it and present the user with new plots and tables.

This means adding tooling to existing code which allows users to compare scenarios if presamples have been used.

This will likely require a massive overhaul of the `Contributions` and an extension of the `PresamplesContributions` classes.
Also, some tabs in the LCA results tabs must be able to recognize that a scenario analysis has been done and present additional comparison options, these are:

**LCA Results tab**:

- [x]  Switch between scenarios in the overview subtab.
- [x] 'by LCIA method' plot is extended to show all scenario results for each functional unit (each single bar is split into multiple)

**Contributions tabs**:
- [x] An additional 'Compare scenarios' toggle which allows users to select a combination of functional unit and impact category and generates a plot and table with the resulting contributions per scenario.
- [x] Handling in the Contributions (sub)class for putting together a dataframe containing scenario data.

**Monte Carlo tab**:
- [x] Add a simple drop-down menu to select which scenario to run monte carlo analysis on.
- ~~(_If possible_) Add a new 'run MC on all scenarios' button which will give the user two warnings before running monte carlo analyses on all the scenarios (s * mc * fu * m means lots of combinations) and presenting either a very cluttered single plot or multiple plots stacked together.~~